### PR TITLE
Mark package as public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RUM React Integration
+# RUM React Integration - forked from [DataDog repository](https://github.com/DataDog/rum-react-integration-examples)
 
 ## Overview
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@nordcloud/rum-react-integration",
   "version": "1.0.0-alpha",
-  "private": "true",
   "license": "Apache-2.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Motivation

In order to release package as public, flag `private` had to be removed from `package.json`
---

I have gone over the [contributing](https://github.com/DataDog/rum-react-integration/blob/master/CONTRIBUTING.md) documentation.